### PR TITLE
Add standard TV Latest node

### DIFF
--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -542,3 +542,6 @@ msgctxt "#30286"
 msgid "Movies - Unwatched"
 msgstr ""
 
+msgctxt "#30287"
+msgid "TV Shows - Latest"
+msgstr ""

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -545,3 +545,7 @@ msgstr ""
 msgctxt "#30287"
 msgid "TV Shows - Latest"
 msgstr ""
+
+msgctxt "#30288"
+msgid " - Latest"
+msgstr ""

--- a/resources/lib/functions.py
+++ b/resources/lib/functions.py
@@ -588,7 +588,10 @@ def processDirectory(results, progress, params):
         name_format = settings.getSetting(name_format)
 
     dirItems = []
-    result = results.get("Items")
+    try:
+        result = results.get("Items")
+    except:
+        result = results
     if result is None:
         result = []
 
@@ -653,7 +656,7 @@ def processDirectory(results, progress, params):
 
         # set the item name
         # override with name format string from request
-        if name_format is not None:
+        if (name_format is not None) and (item.get("Type") == "Episode"):
             nameInfo = {}
             nameInfo["ItemName"] = item.get("Name", "").encode('utf-8')
             nameInfo["SeriesName"] = item.get("SeriesName", "").encode('utf-8')

--- a/resources/lib/functions.py
+++ b/resources/lib/functions.py
@@ -585,9 +585,10 @@ def processDirectory(results, progress, params):
     name_format = params.get("name_format", None)
     if name_format is not None:
         name_format = urllib.unquote(name_format)
-        name_formatting = settings.getSetting(name_format)
-        if name_format == "latest_name_format":
-            name_formatting = settings.getSetting("episode_name_format")
+        tokens = name_format.split("|")
+        name_format_type = tokens[0]
+        name_format = settings.getSetting(tokens[1])
+
     dirItems = []
     if results is None:
         result = []
@@ -608,7 +609,7 @@ def processDirectory(results, progress, params):
                       '&IsMissing=false' +
                       '&Fields=' + detailsString +
                       '&format=json')
-        if (progress != None):
+        if progress is not None:
             progress.close()
         params["media_type"] = "Episodes"
         getContent(season_url, params)
@@ -657,14 +658,14 @@ def processDirectory(results, progress, params):
 
         # set the item name
         # override with name format string from request
-        if (name_format is not None) and (name_format == 'latest_name_format' and isFolder == True) != True:
+        if name_format is not None and item.get("Type", "") == name_format_type:
             nameInfo = {}
             nameInfo["ItemName"] = item.get("Name", "").encode('utf-8')
             nameInfo["SeriesName"] = item.get("SeriesName", "").encode('utf-8')
             nameInfo["SeasonIndex"] = tempSeason
             nameInfo["EpisodeIndex"] = tempEpisode
-            log.debug("FormatName : %s | %s" % (name_formatting, nameInfo))
-            tempTitle = name_formatting.format(**nameInfo).strip()
+            log.debug("FormatName : %s | %s" % (name_format, nameInfo))
+            tempTitle = name_format.format(**nameInfo).strip()
 
         else:
             if (item.get("Name") != None):

--- a/resources/lib/functions.py
+++ b/resources/lib/functions.py
@@ -585,8 +585,9 @@ def processDirectory(results, progress, params):
     name_format = params.get("name_format", None)
     if name_format is not None:
         name_format = urllib.unquote(name_format)
-        name_format = settings.getSetting(name_format)
-
+        name_formatting = settings.getSetting(name_format)
+        if name_format == "latest_name_format":
+            name_formatting = settings.getSetting("episode_name_format")
     dirItems = []
     if results is None:
         result = []
@@ -656,14 +657,14 @@ def processDirectory(results, progress, params):
 
         # set the item name
         # override with name format string from request
-        if (name_format is not None) and (item.get("Type") == "Episode"):
+        if (name_format is not None) and (name_format == 'latest_name_format' and isFolder == True) != True:
             nameInfo = {}
             nameInfo["ItemName"] = item.get("Name", "").encode('utf-8')
             nameInfo["SeriesName"] = item.get("SeriesName", "").encode('utf-8')
             nameInfo["SeasonIndex"] = tempSeason
             nameInfo["EpisodeIndex"] = tempEpisode
-            log.debug("FormatName : %s | %s" % (name_format, nameInfo))
-            tempTitle = name_format.format(**nameInfo).strip()
+            log.debug("FormatName : %s | %s" % (name_formatting, nameInfo))
+            tempTitle = name_formatting.format(**nameInfo).strip()
 
         else:
             if (item.get("Name") != None):

--- a/resources/lib/functions.py
+++ b/resources/lib/functions.py
@@ -592,9 +592,9 @@ def processDirectory(results, progress, params):
     dirItems = []
     if results is None:
         result = []
-    if "Items" in results:
+    if isinstance(results, dict):
         result = results.get("Items") 
-    else: 
+    else:
         result = results
 
     # flatten single season

--- a/resources/lib/functions.py
+++ b/resources/lib/functions.py
@@ -588,12 +588,12 @@ def processDirectory(results, progress, params):
         name_format = settings.getSetting(name_format)
 
     dirItems = []
-    try:
-        result = results.get("Items")
-    except:
-        result = results
-    if result is None:
+    if results is None:
         result = []
+    if "Items" in results:
+        result = results.get("Items") 
+    else: 
+        result = results
 
     # flatten single season
     # if there is only one result and it is a season and you have flatten signle season turned on then

--- a/resources/lib/menu_functions.py
+++ b/resources/lib/menu_functions.py
@@ -438,7 +438,7 @@ def getCollections(detailsString):
                          '&IncludeItemTypes=Episode' +
                          '&ImageTypeLimit=1' +
                          '&format=json')
-    item_data['name_format'] = 'latest_name_format'
+    item_data['name_format'] = 'Episode|episode_name_format'
     collections.append(item_data)
 
     item_data = {}

--- a/resources/lib/menu_functions.py
+++ b/resources/lib/menu_functions.py
@@ -438,7 +438,7 @@ def getCollections(detailsString):
                          '&IncludeItemTypes=Episode' +
                          '&ImageTypeLimit=1' +
                          '&format=json')
-    item_data['name_format'] = 'episode_name_format'
+    item_data['name_format'] = 'latest_name_format'
     collections.append(item_data)
 
     item_data = {}

--- a/resources/lib/menu_functions.py
+++ b/resources/lib/menu_functions.py
@@ -236,6 +236,24 @@ def getCollections(detailsString):
                 'media_type': 'Episodes',
                 'name_format': 'Episode|episode_name_format'})
             collections.append({
+                'title': item_name + i18n('_latest'),
+                'thumbnail': downloadUtils.getArtwork(item, "Primary", server=server),
+                'path': ('{server}/emby/Users/{userid}/Items/Latest' +
+                         '?ParentId=' + item.get("Id") +
+                         '&Limit={ItemLimit}' +
+                         '&IsVirtualUnaired=false' +
+                         '&IsMissing=False' +
+                         '&Fields=' + detailsString +
+                         '&SortBy=DateCreated' +
+                         '&SortOrder=Descending' +
+                         '&Filters=IsUnplayed' +
+                         '&Recursive=true' +
+                         '&IncludeItemTypes=Episode' +
+                         '&ImageTypeLimit=1' +
+                         '&format=json'),
+                'media_type': 'Episodes',
+                'name_format': 'Episode|episode_name_format'})            
+            collections.append({
                 'title': item_name + i18n('_recently_added'),
                 'thumbnail': downloadUtils.getArtwork(item, "Primary", server=server),
                 'path': ('{server}/emby/Users/{userid}/Items' +

--- a/resources/lib/menu_functions.py
+++ b/resources/lib/menu_functions.py
@@ -234,7 +234,7 @@ def getCollections(detailsString):
                          '&ImageTypeLimit=1' +
                          '&format=json'),
                 'media_type': 'Episodes',
-                'name_format': 'episode_name_format'})
+                'name_format': 'Episode|episode_name_format'})
             collections.append({
                 'title': item_name + i18n('_recently_added'),
                 'thumbnail': downloadUtils.getArtwork(item, "Primary", server=server),
@@ -252,7 +252,7 @@ def getCollections(detailsString):
                          '&ImageTypeLimit=1' +
                          '&format=json'),
                 'media_type': 'Episodes',
-                'name_format': 'episode_name_format'})
+                'name_format': 'Episode|episode_name_format'})
             collections.append({
                 'title': item_name + i18n('_next_up'),
                 'thumbnail': downloadUtils.getArtwork(item, "Primary", server=server),
@@ -268,7 +268,7 @@ def getCollections(detailsString):
                          '&ImageTypeLimit=1' +
                          '&format=json'),
                 'media_type': 'Episodes',
-                'name_format': 'episode_name_format'})
+                'name_format': 'Episode|episode_name_format'})
 
         if collection_type == "movies":
             collections.append({
@@ -452,7 +452,7 @@ def getCollections(detailsString):
                          '&IncludeItemTypes=Episode' +
                          '&ImageTypeLimit=1' +
                          '&format=json')
-    item_data['name_format'] = 'episode_name_format'
+    item_data['name_format'] = 'Episode|episode_name_format'
     collections.append(item_data)
 
     item_data = {}
@@ -470,7 +470,7 @@ def getCollections(detailsString):
                          '&IncludeItemTypes=Episode' +
                          '&ImageTypeLimit=1' +
                          '&format=json')
-    item_data['name_format'] = 'episode_name_format'
+    item_data['name_format'] = 'Episode|episode_name_format'
     collections.append(item_data)
 
     item_data = {}
@@ -486,7 +486,7 @@ def getCollections(detailsString):
                          '&IncludeItemTypes=Episode' +
                          '&ImageTypeLimit=1' +
                          '&format=json')
-    item_data['name_format'] = 'episode_name_format'
+    item_data['name_format'] = 'Episode|episode_name_format'
     collections.append(item_data)
 
     item_data = {}

--- a/resources/lib/menu_functions.py
+++ b/resources/lib/menu_functions.py
@@ -423,6 +423,25 @@ def getCollections(detailsString):
     collections.append(item_data)
 
     item_data = {}
+    item_data['title'] = i18n('tvshows_latest')
+    item_data['media_type'] = 'Episodes'
+    item_data['path'] = ('{server}/emby/Users/{userid}/Items/Latest' +
+                         '?Limit={ItemLimit}' +
+                         '&Recursive=true' +
+                         '&GroupItems=true' +
+                         '&SortBy=DateCreated' +
+                         '&Fields=' + detailsString +
+                         '&SortOrder=Descending' +
+                         '&Filters=IsUnplayed' +
+                         '&IsVirtualUnaired=false' +
+                         '&IsMissing=False' +
+                         '&IncludeItemTypes=Episode' +
+                         '&ImageTypeLimit=1' +
+                         '&format=json')
+    item_data['name_format'] = 'episode_name_format'
+    collections.append(item_data)
+
+    item_data = {}
     item_data['title'] = i18n('episodes_in_progress')
     item_data['media_type'] = 'Episodes'
     item_data['path'] = ('{server}/emby/Users/{userid}/Items' +

--- a/resources/lib/translation.py
+++ b/resources/lib/translation.py
@@ -95,5 +95,6 @@ STRINGS = {
     'tvshows_unwatched': 30279,
     '_unwatched': 30285,
     'movies_unwatched': 30286,
-    'tvshows_latest' : 30287
+    'tvshows_latest' : 30287,
+    '_latest' : 30288
 }

--- a/resources/lib/translation.py
+++ b/resources/lib/translation.py
@@ -94,5 +94,6 @@ STRINGS = {
     'show_clients': 30017,
     'tvshows_unwatched': 30279,
     '_unwatched': 30285,
-    'movies_unwatched': 30286
+    'movies_unwatched': 30286,
+    'tvshows_latest' : 30287
 }


### PR DESCRIPTION
Add standard Emby TV Latest node.

Do not expect a merge on this, but rather just get discussion of details started.

These are the minimal changes to the current code set to display the standard Latest node, which includes a single episode if only one unwatched items exists, and a link to the series if there are more than one unwatched/latest.

This node works with Skin Helper.

Please review the changes - the standard nodes(NextUp as well) return the object one layer deeper than the 'old style' queries, so not sure if you are okay with the try/except there.  