### PR TITLE
fix artwork for episodes in widgets

### DIFF
--- a/resources/lib/downloadutils.py
+++ b/resources/lib/downloadutils.py
@@ -209,7 +209,7 @@ class DownloadUtils():
         log.debug("userid: {0}", userid)
 
         WINDOW.setProperty("userid", userid)
-        xbmcgui.Window(10000).setProperty("EmbyUserImage", userImage)
+        WINDOW.setProperty("userimage", userImage)
 
         return userid
 

--- a/resources/lib/downloadutils.py
+++ b/resources/lib/downloadutils.py
@@ -135,6 +135,10 @@ class DownloadUtils():
             artwork += '&MaxHeight=%s' % height
         return artwork
 
+    def get_user_artwork(self, item_id, item_type):
+        # Load user information set by UserClient
+        return "%s/emby/Users/%s/Images/%s?Format=original" % (self.getServer(), item_id, item_type)
+
     def getUserId(self):
 
         WINDOW = HomeWindow()
@@ -174,10 +178,13 @@ class DownloadUtils():
         log.debug("GETUSER_JSONDATA_02: {0}", result)
 
         userid = ""
+        userImage = ""
         secure = False
         for user in result:
             if (user.get("Name") == unicode(userName, "utf-8")):
                 userid = user.get("Id")
+                if "PrimaryImageTag" in user:
+                    userImage =  self.get_user_artwork(userid, 'Primary')
                 log.debug("Username Found: {0}", user.get("Name"))
                 if (user.get("HasPassword") == True):
                     secure = True
@@ -202,6 +209,7 @@ class DownloadUtils():
         log.debug("userid: {0}", userid)
 
         WINDOW.setProperty("userid", userid)
+        xbmcgui.Window(10000).setProperty("EmbyUserImage", userImage)
 
         return userid
 

--- a/resources/lib/downloadutils.py
+++ b/resources/lib/downloadutils.py
@@ -95,7 +95,7 @@ class DownloadUtils():
                 tagName = 'SeriesPrimaryImageTag'
                 idName = 'SeriesId'
             else:
-                tagName = 'Parent%sTag' % art_type
+                tagName = 'Parent%sImageTag' % art_type
                 idName = 'Parent%sItemId' % art_type
             parent_image_id = data[idName]
             parent_image_tag = data[tagName]

--- a/resources/lib/utils.py
+++ b/resources/lib/utils.py
@@ -237,7 +237,7 @@ def getArt(item, server, widget=False):
         art['tvshow.fanart'] = downloadUtils.getArtwork(item, "Backdrop", parent=False, server=server)
 
     if item_type == "Episode":
-        art['thumb'] = art['thumb'] if art['thumb'] else downloadUtils.getArtwork(item, "Thumb", server=server)
+        art['landscape'] = downloadUtils.getArtwork(item, "Thumb", parent=True, server=server)
     else:
         art['poster'] = art['thumb']
 

--- a/resources/lib/utils.py
+++ b/resources/lib/utils.py
@@ -204,6 +204,7 @@ def getArt(item, server, widget=False):
         'clearart': '',
         'discart': '',
         'landscape': '',
+        'tvshow.fanart': '',
         'tvshow.poster': '',
         'tvshow.clearart': '',
         'tvshow.banner': '',
@@ -227,15 +228,16 @@ def getArt(item, server, widget=False):
         art['tvshow.clearart'] = downloadUtils.getArtwork(item, "Logo", parent=True, server=server)
         art['tvshow.banner'] = downloadUtils.getArtwork(item, "Banner", parent=True, server=server)
         art['tvshow.landscape'] = downloadUtils.getArtwork(item, "Thumb", parent=True, server=server)
+        art['tvshow.fanart'] = downloadUtils.getArtwork(item, "Backdrop", parent=True, server=server)
     elif item_type == "Series":
         art['tvshow.poster'] = downloadUtils.getArtwork(item, "Primary", parent=False, server=server)
         art['tvshow.clearart'] = downloadUtils.getArtwork(item, "Logo", parent=False, server=server)
         art['tvshow.banner'] = downloadUtils.getArtwork(item, "Banner", parent=False, server=server)
         art['tvshow.landscape'] = downloadUtils.getArtwork(item, "Thumb", parent=False, server=server)
+        art['tvshow.fanart'] = downloadUtils.getArtwork(item, "Backdrop", parent=False, server=server)
 
     if item_type == "Episode":
         art['thumb'] = art['thumb'] if art['thumb'] else downloadUtils.getArtwork(item, "Thumb", server=server)
-        art['landscape'] = art['thumb'] if art['thumb'] else downloadUtils.getArtwork(item, "Thumb", parent=True, server=server)
     else:
         art['poster'] = art['thumb']
 


### PR DESCRIPTION
This fixes the next up widget and recent added tv shows widget where it was missing the tvshow.landscape, incorrectly retrieving the parent thumb and setting the landscape for episode incorrectly to the episode thumb