### PR TITLE
Allow authentication on older servers

### DIFF
--- a/resources/lib/downloadutils.py
+++ b/resources/lib/downloadutils.py
@@ -231,8 +231,13 @@ class DownloadUtils():
         url = "{server}/emby/Users/AuthenticateByName?format=json"
 
         sha1 = hashlib.sha1(settings.getSetting('password'))
+        md5 = hashlib.md5(settings.getSetting('password'))
+        plain = settings.getSetting('password')
 
-        messageData = "username=" + urllib.quote(settings.getSetting('username')) + "&password=" + sha1.hexdigest()
+        messageData = ("username=" + urllib.quote(settings.getSetting('username')) +
+                       "&password=" + sha1.hexdigest() +
+                       "&passwordMd5=" + md5.hexdigest() +
+                       "&pw=" + plain)
 
         resp = self.downloadUrl(url, postBody=messageData, method="POST", suppress=True, authenticate=False)
 


### PR DESCRIPTION
As stated in [emby's documentation](https://github.com/MediaBrowser/Emby/wiki/Authentication#authenticating-a-user) we have to use 3 different parameters for a user password when attempting authentication. We have to provide a Sha1, MD5 and plain text version.