### PR TITLE
updates for compatibility with up next addon, more generic approach

### DIFF
--- a/resources/lib/functions.py
+++ b/resources/lib/functions.py
@@ -1085,7 +1085,7 @@ def PLAY(params):
     play_info["media_source_id"] = media_source_id
     play_info["use_default"] = use_default
     log.info("Sending embycon_play_action : {0}", play_info)
-    send_event_notification("embycon_play_action", play_info)
+    send_event_notification("play_action", play_info)
 
 
 def playTrailer(id):

--- a/resources/lib/play_utils.py
+++ b/resources/lib/play_utils.py
@@ -351,40 +351,64 @@ def send_next_episode_details(item):
     next_item_details = extract_item_info(next_episode, gui_options)
 
     current_item = {}
-    current_item["id"] = item_details.id
+    current_item["episodeid"] = item_details.id
+    current_item["tvshowid"] = item_details.series_name
     current_item["title"] = item_details.name
-    current_item["image"] = item_details.art.get('tvshow.poster', '')
-    current_item["thumb"] = item_details.art.get('thumb', '')
-    current_item["fanartimage"] = item_details.art.get('tvshow.fanart', '')
-    current_item["overview"] = item_details.plot
-    current_item["tvshowtitle"] = item_details.series_name
+    current_item["art"] = {}
+    current_item["art"]["tvshow.poster"] = item_details.art.get('tvshow.poster', '')
+    current_item["art"]["thumb"] = item_details.art.get('thumb', '')
+    current_item["art"]["tvshow.fanart"] = item_details.art.get('tvshow.fanart', '')
+    current_item["art"]["tvshow.landscape"] = item_details.art.get('tvshow.landscape', '')
+    current_item["art"]["tvshow.clearart"] = item_details.art.get('tvshow.clearart', '')
+    current_item["art"]["tvshow.clearlogo"] = item_details.art.get('tvshow.clearlogo', '')
+    current_item["plot"] = item_details.plot
+    current_item["showtitle"] = item_details.series_name
     current_item["playcount"] = item_details.play_count
     current_item["season"] = item_details.season_number
     current_item["episode"] = item_details.episode_number
     current_item["rating"] = item_details.critic_rating
-    current_item["year"] = item_details.year
+    current_item["firstaired"] = item_details.year
+    play_info = {}
+    play_info["item_id"] = item_details.id
+    play_info["auto_resume"] = False
+    play_info["force_transcode"] = False
+    current_item["playinfo"] = play_info
+    current_item["id"] = "embycon"
+
 
     next_item = {}
-    next_item["id"] = next_item_details.id
+    next_item["episodeid"] = next_item_details.id
+    next_item["tvshowid"] = next_item_details.series_name
     next_item["title"] = next_item_details.name
-    next_item["image"] = next_item_details.art.get('tvshow.poster', '')
-    next_item["thumb"] = next_item_details.art.get('thumb', '')
-    next_item["fanartimage"] = next_item_details.art.get('tvshow.fanart', '')
-    next_item["overview"] = next_item_details.plot
-    next_item["tvshowtitle"] = next_item_details.series_name
+    next_item["art"] = {}
+    next_item["art"]["tvshow.poster"] = next_item_details.art.get('tvshow.poster', '')
+    next_item["art"]["thumb"] = next_item_details.art.get('thumb', '')
+    next_item["art"]["tvshow.fanart"] = next_item_details.art.get('tvshow.fanart', '')
+    next_item["art"]["tvshow.landscape"] = next_item_details.art.get('tvshow.landscape', '')
+    next_item["art"]["tvshow.clearart"] = next_item_details.art.get('tvshow.clearart', '')
+    next_item["art"]["tvshow.clearlogo"] = next_item_details.art.get('tvshow.clearlogo', '')
+    next_item["plot"] = next_item_details.plot
+    next_item["showtitle"] = next_item_details.series_name
     next_item["playcount"] = next_item_details.play_count
     next_item["season"] = next_item_details.season_number
     next_item["episode"] = next_item_details.episode_number
     next_item["rating"] = next_item_details.critic_rating
-    next_item["year"] = next_item_details.year
+    next_item["firstaired"] = next_item_details.year
+    play_info = {}
+    play_info["item_id"] = next_item_details.id
+    play_info["auto_resume"] = False
+    play_info["force_transcode"] = False
+    next_item["playinfo"] = play_info
+    next_item["id"] = "embycon"
+
 
     next_info = {
-        "current_item": current_item,
-        "next_item": next_item
+        "current_episode": current_item,
+        "next_episode": next_item
     }
 
     log.debug("send_next_episode_details: {0}", next_info)
-    send_event_notification("embycon_next_episode", next_info)
+    send_event_notification("upnext_data", next_info, "upnextprovider")
 
 
 def setListItemProps(id, listItem, result, server, extra_props, title):
@@ -712,7 +736,7 @@ def promptForStopActions(item_id, current_possition):
                 play_info["item_id"] = next_item_id
                 play_info["auto_resume"] = "-1"
                 play_info["force_transcode"] = False
-                send_event_notification("embycon_play_action", play_info)
+                send_event_notification("play_action", play_info)
 
 
 def stopAll(played_information):
@@ -881,7 +905,7 @@ class PlaybackService(xbmc.Monitor):
             return
 
         signal = method.split('.', 1)[-1]
-        if signal != "embycon_play_action":
+        if signal != "play_action":
             return
 
         data_json = json.loads(data)

--- a/resources/lib/utils.py
+++ b/resources/lib/utils.py
@@ -276,9 +276,8 @@ def single_urlencode(text):
     return text.decode('utf-8') #return the result again as unicode
 
 
-def send_event_notification(method, data):
+def send_event_notification(method, data, source_id='embycon'):
     next_data = json.dumps(data)
-    source_id = "embycon"
     data = '\\"[\\"{0}\\"]\\"'.format(binascii.hexlify(next_data))
     command = 'XBMC.NotifyAll({0}.SIGNAL,{1},{2})'.format(source_id, method, data)
     log.debug("Sending notification event data: {0}", command)


### PR DESCRIPTION
Hi,

I'm replacing the next up addon with a new 'up next' one and made a couple of changes so that the communication was more generic. A couple of little changes like you now sending across the play_info and the id to call. 

The up next addon still needs skinned properly (sualfred is working on it) but works well and simply has the one popup. For info on the data changes you can see here [addon Integration](https://github.com/im85288/service.upnext/wiki/Addon-Integration)