### PR TITLE
update from deprecated youtube playback url

### DIFF
--- a/resources/lib/functions.py
+++ b/resources/lib/functions.py
@@ -890,7 +890,7 @@ def playTrailer(id):
         elif trailer.get("type") == "remote":
             youtube_id = trailer.get("url").rsplit('=', 1)[1]
             log.debug("YoutubeID: {0}", youtube_id)
-            youtube_plugin = "PlayMedia(plugin://plugin.video.youtube/?action=play_video&videoid=%s)" % youtube_id
+            youtube_plugin = "PlayMedia(plugin://plugin.video.youtube/play/?video_id=%s)" % youtube_id
             xbmc.executebuiltin(youtube_plugin)
 
 


### PR DESCRIPTION
resolves:
```
03:29:13.977 T:1584  NOTICE: [plugin.video.youtube] Running: YouTube (6.2.3) on Leia (Kodi-18.0) with Python 2.7.13
                                            	Path: /
                                            	Params: {'action': 'play_video', 'videoid': 'n9ukI7khQpE'}
03:29:13.982 T:1584 WARNING: [plugin.video.youtube] DEPRECATED "plugin://plugin.video.youtube/?action=play_video&videoid=n9ukI7khQpE"
03:29:13.982 T:1584 WARNING: [plugin.video.youtube] USE INSTEAD "plugin://plugin.video.youtube/play/?video_id=n9ukI7khQpE"
```