### PR TITLE
Fix encoding errors in get_emby_url

### DIFF
--- a/resources/lib/utils.py
+++ b/resources/lib/utils.py
@@ -37,13 +37,14 @@ def get_emby_url(base_url, params):
     >>> params = {
     ... "unicodeChar": u'\xc6',
     ... "spaced String": "spaced String",
+    ... "placeHolder": "{field_filters}",
     ... "unicodeInt": u'-1',
     ... "boolean": True,
     ... "none": None,
     ... "int": 1,
     ... }
     >>> get_emby_url("https://127.0.0.1/.../Items", params)
-    'https://127.0.0.1/.../Items?unicodeChar=%C3%86&format=json&int=1&boolean=True&spaced+String=spaced+String&unicodeInt=-1'
+    'https://127.0.0.1/.../Items?unicodeChar=%C3%86&int=1&none=None&boolean=True&spaced+String=spaced+String&placeHolder={field_filters}&unicodeInt=-1'
 
     :param base_url: Emby server url.
     :param params: Dictionary of form fields.
@@ -54,13 +55,20 @@ def get_emby_url(base_url, params):
     :rtype: <str>
     """
     params["format"] = "json"
-    param_string = urllib.urlencode(
-        {
-            key: value.encode("utf8") if isinstance(value, unicode) else value
-            for key, value in params.items()
-            if value
-        }
+
+    # Cast values
+    params = {
+        key: val.encode("utf8") if isinstance(val, unicode) else str(val)
+        for key, val in params.items()
+        if val
+    }
+
+    # Escape keys and values except for placeholders
+    param_string = "&".join(
+        urllib.quote_plus(key) + "=" + urllib.quote_plus(val, safe="{}")
+        for key, val in params.items()
     )
+
     return base_url + "?" + param_string
 
 

--- a/resources/lib/utils.py
+++ b/resources/lib/utils.py
@@ -60,7 +60,7 @@ def get_emby_url(base_url, params):
     params = {
         key: val.encode("utf8") if isinstance(val, unicode) else str(val)
         for key, val in params.items()
-        if val
+        if val is not None
     }
 
     # Escape keys and values except for placeholders

--- a/resources/lib/utils.py
+++ b/resources/lib/utils.py
@@ -1,3 +1,4 @@
+# coding: utf-8
 # Gnu General Public License - see LICENSE.TXT
 import xbmcaddon
 import xbmc
@@ -26,12 +27,40 @@ log = SimpleLogging(__name__)
 
 
 def get_emby_url(base_url, params):
+    """Forge an url with the given form fields
+
+    The resulting params is a series of key=value pairs separated by '&'
+    characters, where both key and value are quoted using percent-encoding.
+
+    :Example:
+
+    >>> params = {
+    ... "unicodeChar": u'\xc6',
+    ... "spaced String": "spaced String",
+    ... "unicodeInt": u'-1',
+    ... "boolean": True,
+    ... "none": None,
+    ... "int": 1,
+    ... }
+    >>> get_emby_url("https://127.0.0.1/.../Items", params)
+    'https://127.0.0.1/.../Items?unicodeChar=%C3%86&format=json&int=1&boolean=True&spaced+String=spaced+String&unicodeInt=-1'
+
+    :param base_url: Emby server url.
+    :param params: Dictionary of form fields.
+        Note: values can be str, unicode, boolean, int, None.
+    :type base_url: <str>
+    :type params: <dict>
+    :return: Url
+    :rtype: <str>
+    """
     params["format"] = "json"
-    param_list = []
-    for key in params:
-        if params[key] is not None:
-            param_list.append(key + "=" + str(params[key]))
-    param_string = "&".join(param_list)
+    param_string = urllib.urlencode(
+        {
+            key: value.encode("utf8") if isinstance(value, unicode) else value
+            for key, value in params.items()
+            if value
+        }
+    )
     return base_url + "?" + param_string
 
 


### PR DESCRIPTION
Hello, first of all, thank you for your work on this very useful addon.

I noticed an encoding error in the urls generated by the get_emby_url function
https://github.com/faush01/plugin.video.embycon/blob/b29a1012c464076dac8f14636b4987e8fdf078ca/resources/lib/utils.py#L28

Here is the stacktrace:

    2020-03-10 23:11:18.354 T:140339495048960   ERROR: EXCEPTION Thrown (PythonToCppException) : -->Python callback/script returned the following error<--
        - NOTE: IGNORING THIS CAN LEAD TO MEMORY LEAKS!
    Error Type: <type 'exceptions.UnicodeEncodeError'>
    Error Contents: 'ascii' codec can't encode character u'\xc6' in position 0: ordinal not in range(128)
    Traceback (most recent call last):
        File "/home/pi/.kodi/addons/plugin.video.embycon/default.py", line 18, in <module>
        mainEntryPoint()
        File "/home/pi/.kodi/addons/plugin.video.embycon/resources/lib/tracking.py", line 20, in wrapper
        value = func(*args, **kwargs)
        File "/home/pi/.kodi/addons/plugin.video.embycon/resources/lib/functions.py", line 109, in mainEntryPoint
        show_movie_alpha_list(params)
        File "/home/pi/.kodi/addons/plugin.video.embycon/resources/lib/menu_functions.py", line 398, in show_movie_alpha_list
        url = get_emby_url("{server}/emby/Users/{userid}/Items", params)
        File "/home/pi/.kodi/addons/plugin.video.embycon/resources/lib/utils.py", line 33, in get_emby_url
        param_list.append(key + "=" + str(params[key]))
    UnicodeEncodeError: 'ascii' codec can't encode character u'\xc6' in position 0: ordinal not in range(128)
    -->End of Python script error report<--

After some debugs I saw that the utf8 character "Æ" was not converted correctly.
So I documented and rewrote this function using the urlencode function of urllib already designed for properly manage the urls fields and their escaping.

I haven't seen any test suite on the project, so I just inserted a doctest, which I think covers all the possible values of the argument `params`.

Concerning the migration to Python3, this should be easy since urlencode is still available thanks to this import:

    from urllib.parse import urlencode
    urlencode({k: v.encode("utf-8") if isinstance(v, str) else v for k, v in d.items()})

Generally speaking, to avoid such inconveniences in Python2 it is advisable to apply
the following instructions:

- Put `# coding: utf-8` or similar at the beginning of the file just after the shebang;
- Import `from __future__ import unicode_literals` at the beginning of each module;
- Decode inputs with `un_chain.decode('utf8')`.
- Encode the outputs with `a_chain.encode('utf8')`.

Moreover, I see that Kodi only references the version 1.9.33 of this project while the Emby repository references version 1.9.60;
These versions are older than yours, do you have an explanation for that?

Yours sincerely.