### PR TITLE
Fix for new Kodi Matrix changes

### DIFF
--- a/resources/lib/utils.py
+++ b/resources/lib/utils.py
@@ -313,7 +313,7 @@ def send_event_notification(method, data):
     base64_data = base64.b64encode(message_data.encode("utf-8"))
     base64_data = base64_data.decode("utf-8")
     escaped_data = '\\"[\\"{0}\\"]\\"'.format(base64_data)
-    command = 'XBMC.NotifyAll({0}.SIGNAL,{1},{2})'.format(source_id, method, escaped_data)
+    command = 'NotifyAll({0}.SIGNAL,{1},{2})'.format(source_id, method, escaped_data)
     log.debug("Sending notification event data: {0}", command)
     xbmc.executebuiltin(command)
 

--- a/resources/lib/websocket_client.py
+++ b/resources/lib/websocket_client.py
@@ -168,7 +168,7 @@ class WebSocketClient(threading.Thread):
 
             elif command == 'SetRepeatMode':
                 mode = arguments['RepeatMode']
-                xbmc.executebuiltin('xbmc.PlayerControl(%s)' % mode)
+                xbmc.executebuiltin('PlayerControl(%s)' % mode)
 
         elif command == 'DisplayMessage':
 


### PR DESCRIPTION
executebuiltin commands can no longer have the xbmc. prefix. removed the 2 instances i found of this to allow embycon to continue working on the latest matrix nightlies