### PR TITLE
Fixed issues with removed functions in v19.

### DIFF
--- a/resources/lib/action_menu.py
+++ b/resources/lib/action_menu.py
@@ -25,7 +25,7 @@ class ActionAutoClose(threading.Thread):
 
     def run(self):
         log.debug("ActionAutoClose Running")
-        while not xbmc.abortRequested and not self.stop_thread:
+        while not xbmc.Monitor().abortRequested() and not self.stop_thread:
             time_since_last = time.time() - self.last_interaction
             log.debug("ActionAutoClose time_since_last : {0}", time_since_last)
 

--- a/resources/lib/context_monitor.py
+++ b/resources/lib/context_monitor.py
@@ -20,7 +20,7 @@ class ContextMonitor(threading.Thread):
         context_up = False
         is_embycon_item = False
 
-        while not xbmc.abortRequested and not self.stop_thread:
+        while not xbmc.Monitor().abortRequested() and not self.stop_thread:
 
             if xbmc.getCondVisibility("Window.IsActive(fullscreenvideo) | Window.IsActive(visualisation)"):
                 xbmc.sleep(1000)
@@ -39,7 +39,7 @@ class ContextMonitor(threading.Thread):
 
         '''
 
-        while not xbmc.abortRequested and not self.stop_thread:
+        while not xbmc.Monitor().abortRequested() and not self.stop_thread:
 
             if xbmc.getCondVisibility("Window.IsActive(fullscreenvideo) | Window.IsActive(visualisation)"):
                 xbmc.sleep(1000)

--- a/resources/lib/functions.py
+++ b/resources/lib/functions.py
@@ -585,7 +585,7 @@ def populate_listitem(item_id):
     server = downloadUtils.getServer()
 
     art = getArt(result, server=server)
-    list_item.setIconImage(art['thumb'])  # back compat
+    listItem.setArt({ 'icon': art['thumb'] }) # changed to setArt due to setIconImage removed from v19
     list_item.setProperty('fanart_image', art['fanart'])  # back compat
     list_item.setProperty('discart', art['discart'])  # not avail to setArt
     list_item.setArt(art)

--- a/resources/lib/play_utils.py
+++ b/resources/lib/play_utils.py
@@ -628,7 +628,7 @@ def setListItemProps(id, listItem, result, server, extra_props, title):
     # set up item and item info
 
     art = getArt(result, server=server)
-    listItem.setIconImage(art['thumb'])  # back compat
+    listItem.setArt({ 'icon': art['thumb'] }) # changed to setArt due to setIconImage removed from v19
     listItem.setProperty('fanart_image', art['fanart'])  # back compat
     listItem.setProperty('discart', art['discart'])  # not avail to setArt
     listItem.setArt(art)
@@ -1271,4 +1271,3 @@ class PlaybackService(xbmc.Monitor):
             if skip_select_user is not None and skip_select_user == "true":
                 return
             xbmc.executebuiltin("RunScript(plugin.video.embycon,0,?mode=CHANGE_USER)")
-

--- a/service.py
+++ b/service.py
@@ -114,7 +114,7 @@ if enable_logging:
 # I am switching back to xbmc.abortRequested approach until kodi is fixed or I find a work arround
 prev_user_id = home_window.getProperty("userid")
 
-while not xbmc.abortRequested:
+while not xbmc.Monitor().abortRequested():
 
     try:
         if xbmc.Player().isPlaying():
@@ -162,7 +162,9 @@ while not xbmc.abortRequested:
         log.error("Exception in Playback Monitor: {0}", error)
         log.error("{0}", traceback.format_exc())
 
-    xbmc.sleep(1000)
+    #xbmc.sleep(1000)
+    if xbmc.Monitor().waitForAbort( 1 ):
+        break
 
 image_server.stop()
 


### PR DESCRIPTION
setIconImage removed
xbmc.abortRequested removed, need to use xbmc.Monitor().abortRequested instead
Embycon was blocking Kodi from shutting down due to sleep in service.py, changed to waitForAbort

Some of the other sleep() calls should probably be changed to waitForAbort as well, since https://forum.kodi.tv/showthread.php?tid=354577&pid=2950909#pid2950909 says sleep will block a script from exiting until the timer runs out. I don't know why Embycon wouldn't close with sleep(1000) in service.py since if I understand correctly, it should have only blocked the script from exiting for up to 1 second, but that wasn't my experience. I had to kill Kodi in task manager until i changed the sleep to waitForAbort. I also wasn't sure if changing other sleep() would cause any other issues, but so far just changing that 1 in service.py seems to work fine for me.