### PR TITLE
add option to force fullscreen video

### DIFF
--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -1073,3 +1073,7 @@ msgstr ""
 msgctxt "#30440"
 msgid "Play next"
 msgstr ""
+
+msgctxt "#30441"
+msgid "Force fullscreen video"
+msgstr ""

--- a/resources/language/resource.language.es_es/strings.po
+++ b/resources/language/resource.language.es_es/strings.po
@@ -1074,3 +1074,7 @@ msgstr "Mostrar reproducir el próximo episodio en un momento concreto"
 msgctxt "#30440"
 msgid "Play next"
 msgstr "Reproducir siguiente"
+
+msgctxt "#30441"
+msgid "Force fullscreen video"
+msgstr "Forzar video en pantalla completa"

--- a/resources/lib/play_utils.py
+++ b/resources/lib/play_utils.py
@@ -1236,6 +1236,21 @@ class Service(xbmc.Player):
         home_screen = HomeWindow()
         home_screen.set_property("currently_playing_id", str(emby_item_id))
 
+    def onAVStarted(self):
+        # Will be called when Kodi has a video or audiostream
+
+        if not xbmc.Player().isPlayingVideo():
+            return
+
+        if xbmcaddon.Addon().getSetting('force_fullscreenvideo') == "true":
+            play_data = get_playing_data(self.played_information)
+
+            if play_data is None:
+                return
+
+            log.debug("onAVStarted: ActivateWindow(fullscreenvideo)")
+            xbmc.executebuiltin("ActivateWindow(fullscreenvideo)")
+
     def onPlayBackEnded(self):
         # Will be called when kodi stops playing a file
         log.debug("onPlayBackEnded")

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -23,6 +23,7 @@
 		<setting label="30437" type="lsep"/>
 		<setting type="sep" />
 		<setting id="play_cinema_intros" type="bool" label="30438" default="false" visible="true" enable="true" />
+		<setting id="force_fullscreenvideo" type="bool" label="30441" default="false" visible="true" enable="true" />
 
 		<!--<setting id="playback_type" type="select" label="30206" lvalues="30209|30210|30211" default="1" />-->
 


### PR DESCRIPTION
First of all there's no general problem in your addon. It's more a Kodi problem, but sometimes if i start playing videos from Emby by pushing them with the remote play command, the video is played in the background behind the last used Kodi skin window.
I simple can bring the video window to the foreground by just pushing the specified key (e.g. TAB). But it nerves!
This new option does it automatically, with default to off.