### PR TITLE
re-enable stop command for playbackstart event

### DIFF
--- a/resources/lib/play_utils.py
+++ b/resources/lib/play_utils.py
@@ -1194,7 +1194,7 @@ class Service(xbmc.Player):
 
     def onPlayBackStarted(self):
         # Will be called when xbmc starts playing a file
-        #stop_all_playback(self.played_information)
+        log.debug("onPlayBackStarted")
 
         if not xbmc.Player().isPlaying():
             log.debug("onPlayBackStarted: not playing file!")
@@ -1203,6 +1203,7 @@ class Service(xbmc.Player):
         play_data = get_playing_data(self.played_information)
 
         if play_data is None:
+            stop_all_playback(self.played_information)
             return
 
         play_data["paused"] = False


### PR DESCRIPTION
... but this time at a more suitable position. Background:
If an EmbyCon video is playing and you switch to a live tv channel in Kodi without stopping the video playback first, then Kodi for whatever reason sends a "onPlayBackResumed" event.
This does not happen if you start a new video, then it will be "onPlayBackStopped", which makes sense.
But because of "onPlayBackResumed" the EmbyCon stop command will be send at a later time, when the user stops live tv in Kodi.
This can lead to strange effects in Emby if something depends on playback events there.