### PR TITLE
Fix threading compatibility in Python 3.9

### DIFF
--- a/resources/lib/websocket/_app.py
+++ b/resources/lib/websocket/_app.py
@@ -225,7 +225,7 @@ class WebSocketApp(object):
             If close_frame is set, we will invoke the on_close handler with the
             statusCode and reason from there.
             """
-            if thread and thread.isAlive():
+            if thread and thread.is_alive():
                 event.set()
                 thread.join()
             self.keep_running = False


### PR DESCRIPTION
This change makes the plugin compatible with Python 3.9.

I have recently updated Libreelec to version 11 which used Python 3.11. After that I have had the problem that kodi crashed in idle and no longer allowed any input.

The reason is that the theading method `isAlive` was removed in Python 3.9. The new method `is_alive` is available since Python 2.6.

<details>
  <summary>Kodi Log</summary>

  ```
2023-06-17 11:34:06.373 T:800     error <general>: EmbyCon.resources.lib.websocket_client|ERROR|Error: 'Thread' object has no attribute 'isAlive'
2023-06-17 11:34:06.373 T:800     error <general>: Exception in thread 
2023-06-17 11:34:06.373 T:800     error <general>: Thread-3
2023-06-17 11:34:06.373 T:800     error <general>: :
                                                   
2023-06-17 11:34:06.373 T:800     error <general>: 
2023-06-17 11:34:06.373 T:800     error <general>: Traceback (most recent call last):
                                                   
2023-06-17 11:34:06.373 T:800     error <general>: 
2023-06-17 11:34:06.373 T:800     error <general>:   File "/storage/.kodi/addons/plugin.video.embycon/resources/lib/websocket/_app.py", line 303, in run_forever
                                                   
2023-06-17 11:34:06.374 T:800     error <general>: 
2023-06-17 11:34:06.374 T:800     error <general>:     
2023-06-17 11:34:06.375 T:800     error <general>: dispatcher.read(self.sock.sock, read, check)
2023-06-17 11:34:06.375 T:800     error <general>: 
                                                   
2023-06-17 11:34:06.375 T:800     error <general>: 
2023-06-17 11:34:06.375 T:800     error <general>:   File "/storage/.kodi/addons/plugin.video.embycon/resources/lib/websocket/_app.py", line 51, in read
                                                   
2023-06-17 11:34:06.375 T:777      info <general>: CPythonInvoker(2, /storage/.kodi/addons/plugin.video.embycon/service.py): waiting on thread 139891094546112
2023-06-17 11:34:06.375 T:800     error <general>: 
2023-06-17 11:34:06.375 T:800     error <general>:     
2023-06-17 11:34:06.375 T:800     error <general>: if not read_callback():
2023-06-17 11:34:06.375 T:800     error <general>: 
                                                   
2023-06-17 11:34:06.375 T:800     error <general>: 
2023-06-17 11:34:06.375 T:800     error <general>:  
2023-06-17 11:34:06.375 T:800      info <general>: Skipped 10 duplicate messages..
2023-06-17 11:34:06.375 T:800     error <general>: ^
2023-06-17 11:34:06.375 T:800      info <general>: Skipped 14 duplicate messages..
2023-06-17 11:34:06.375 T:800     error <general>: 
                                                   
2023-06-17 11:34:06.376 T:800     error <general>: 
2023-06-17 11:34:06.376 T:800     error <general>:   File "/storage/.kodi/addons/plugin.video.embycon/resources/lib/websocket/_app.py", line 267, in read
                                                   
2023-06-17 11:34:06.376 T:800     error <general>: 
2023-06-17 11:34:06.376 T:800     error <general>:     
2023-06-17 11:34:06.376 T:800     error <general>: return teardown()
2023-06-17 11:34:06.376 T:800     error <general>: 
                                                   
2023-06-17 11:34:06.376 T:800     error <general>: 
2023-06-17 11:34:06.376 T:800     error <general>:  
2023-06-17 11:34:06.376 T:800      info <general>: Skipped 10 duplicate messages..
2023-06-17 11:34:06.376 T:800     error <general>: ^
2023-06-17 11:34:06.376 T:800      info <general>: Skipped 9 duplicate messages..
2023-06-17 11:34:06.376 T:800     error <general>: 
                                                   
2023-06-17 11:34:06.376 T:800     error <general>: 
2023-06-17 11:34:06.376 T:800     error <general>:   File "/storage/.kodi/addons/plugin.video.embycon/resources/lib/websocket/_app.py", line 228, in teardown
                                                   
2023-06-17 11:34:06.377 T:800     error <general>: 
2023-06-17 11:34:06.377 T:800     error <general>:     
2023-06-17 11:34:06.377 T:800     error <general>: if thread and thread.isAlive():
2023-06-17 11:34:06.377 T:800     error <general>: 
                                                   
2023-06-17 11:34:06.377 T:800     error <general>: 
2023-06-17 11:34:06.377 T:800     error <general>:  
2023-06-17 11:34:06.377 T:800      info <general>: Skipped 17 duplicate messages..
2023-06-17 11:34:06.377 T:800     error <general>: ^
2023-06-17 11:34:06.377 T:800      info <general>: Skipped 13 duplicate messages..
2023-06-17 11:34:06.377 T:800     error <general>: 
                                                   
2023-06-17 11:34:06.377 T:800     error <general>: 
2023-06-17 11:34:06.377 T:800     error <general>: AttributeError
2023-06-17 11:34:06.377 T:800     error <general>: : 
2023-06-17 11:34:06.377 T:800     error <general>: 'Thread' object has no attribute 'isAlive'
2023-06-17 11:34:06.377 T:800     error <general>: . Did you mean: '
2023-06-17 11:34:06.377 T:800     error <general>: is_alive
2023-06-17 11:34:06.377 T:800     error <general>: '?
2023-06-17 11:34:06.377 T:800     error <general>: 
                                                   
2023-06-17 11:34:06.377 T:800     error <general>: 
2023-06-17 11:34:06.377 T:800     error <general>: 
                                                   
2023-06-17 11:34:06.377 T:800     error <general>: 
2023-06-17 11:34:06.377 T:800     error <general>: During handling of the above exception, another exception occurred:
                                                   
2023-06-17 11:34:06.377 T:800     error <general>: 
2023-06-17 11:34:06.377 T:800     error <general>: 
                                                   
2023-06-17 11:34:06.377 T:800     error <general>: 
2023-06-17 11:34:06.377 T:800     error <general>: Traceback (most recent call last):
                                                   
2023-06-17 11:34:06.377 T:800     error <general>: 
2023-06-17 11:34:06.377 T:800     error <general>:   File "/usr/lib/python3.11/threading.py", line 1038, in _bootstrap_inner
                                                   
2023-06-17 11:34:06.378 T:800     error <general>: 
2023-06-17 11:34:06.378 T:800     error <general>:   File "/storage/.kodi/addons/plugin.video.embycon/resources/lib/websocket_client.py", line 271, in run
                                                   
2023-06-17 11:34:06.379 T:800     error <general>: 
2023-06-17 11:34:06.379 T:800     error <general>:     
2023-06-17 11:34:06.379 T:800     error <general>: self._client.run_forever(ping_interval=10)
2023-06-17 11:34:06.379 T:800     error <general>: 
                                                   
2023-06-17 11:34:06.379 T:800     error <general>: 
2023-06-17 11:34:06.379 T:800     error <general>:   File "/storage/.kodi/addons/plugin.video.embycon/resources/lib/websocket/_app.py", line 309, in run_forever
                                                   
2023-06-17 11:34:06.379 T:800     error <general>: 
2023-06-17 11:34:06.379 T:800     error <general>:     
2023-06-17 11:34:06.379 T:800     error <general>: teardown()
2023-06-17 11:34:06.379 T:800     error <general>: 
                                                   
2023-06-17 11:34:06.379 T:800     error <general>: 
2023-06-17 11:34:06.379 T:800     error <general>:   File "/storage/.kodi/addons/plugin.video.embycon/resources/lib/websocket/_app.py", line 228, in teardown
                                                   
2023-06-17 11:34:06.379 T:800     error <general>: 
2023-06-17 11:34:06.380 T:800     error <general>:     
2023-06-17 11:34:06.380 T:800     error <general>: if thread and thread.isAlive():
2023-06-17 11:34:06.380 T:800     error <general>: 
                                                   
2023-06-17 11:34:06.380 T:800     error <general>: 
2023-06-17 11:34:06.380 T:800     error <general>:  
2023-06-17 11:34:06.380 T:800      info <general>: Skipped 17 duplicate messages..
2023-06-17 11:34:06.380 T:800     error <general>: ^
2023-06-17 11:34:06.380 T:800      info <general>: Skipped 13 duplicate messages..
2023-06-17 11:34:06.380 T:800     error <general>: 
                                                   
2023-06-17 11:34:06.380 T:800     error <general>: 
2023-06-17 11:34:06.380 T:800     error <general>: AttributeError
2023-06-17 11:34:06.380 T:800     error <general>: : 
2023-06-17 11:34:06.380 T:800     error <general>: 'Thread' object has no attribute 'isAlive'
2023-06-17 11:34:06.380 T:800     error <general>: . Did you mean: '
2023-06-17 11:34:06.380 T:800     error <general>: is_alive
2023-06-17 11:34:06.380 T:800     error <general>: '?
2023-06-17 11:34:06.380 T:800     error <general>: 
                                                   
2023-06-17 11:34:11.374 T:750     error <general>: CPythonInvoker(2, /storage/.kodi/addons/plugin.video.embycon/service.py): script didn't stop in 5 seconds - let's kill it
  ```

</details>
